### PR TITLE
Implements complete cli interface with multiple enhancements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/cli.py
+++ b/cli.py
@@ -1,16 +1,39 @@
 import sys
 import json
+import argparse
 
 from goop import goop
+
+parser = argparse.ArgumentParser(description='Process user information')
+parser.add_argument('--query', '-q', type=str, help='Query parameter', required=True)
+
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--pages', '-P', type=int, help='Total page count')
+group.add_argument('--count', '-c', type=int, help='Total entries count')
+
+args = parser.parse_args()
+pages = args.pages or 1
+count = args.count
+query = args.query
 
 green = '\033[92m'
 white = '\033[97m'
 yellow = '\033[93m'
 end = '\033[0m'
 
-cookie = '<your facebook cookie>'
+#cookie = '<your facebook cookie>'
+cookie ="sb=boLvXDSrzYhVnIKWXOFFW041; datr=boLvXPKbLlyVoB80_a3jBYga; c_user=100001279151010; xs=81%3AsekDgdXtTHvMpg%3A2%3A1559200373%3A9277%3A4202; dpr=1.125; ; spin=r.1001023063_b.trunk_t.1565064737_s.1_v.2_; fr=04L1QWkX5tO2cXBfm.AWUZ47IHTKAlNM_-5JktDQIYrxE.Bc7meN.yw.F1G.0.0.BdSP4i.AWUFvl3v; wd=1091x838; presence=EDvF3EtimeF1565064744EuserFA21B01279151010A2EstateFDutF1565064744973CEchFDp_5f1B01279151010F1CC"
 
-for page in range(int(sys.argv[2])):
-	result = goop.search(sys.argv[1], cookie, page=page, full=True)
-	for each in result:
-		print ('''%s%s\n%s%s\n%s%s%s\n''' % (green, result[each]['text'], yellow, result[each]['url'], white, result[each]['summary'], end))
+if count:
+    pages = count
+
+for page in range(pages):
+    result = goop.search(query, cookie, page=page, full=True, count=count)
+
+    for each in result:
+	print ('''%s%s\n%s%s\n%s%s%s\n''' % (green, result[each]['text'], yellow, result[each]['url'], white, result[each]['summary'], end))
+
+    if count:
+        count = count - len(result)
+        if count <= 0:
+            break

--- a/cli.py
+++ b/cli.py
@@ -6,13 +6,19 @@ from goop import goop
 
 parser = argparse.ArgumentParser(description='Process user information')
 parser.add_argument('--query', '-q', type=str, help='Query parameter', required=True)
+parser.add_argument('--cookie', type=str, help='Facebook cookie')
 
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--pages', '-P', type=int, help='Total page count')
+group.add_argument('--page', '-p', type=int, help='Page index for retrieval')
+group.add_argument('--range', '-r', type=int, help='Range of page index', nargs=2)
 group.add_argument('--count', '-c', type=int, help='Total entries count')
 
 args = parser.parse_args()
-pages = args.pages or 1
+
+page = args.page
+custom_range = args.range
+pages = args.pages
 count = args.count
 query = args.query
 
@@ -21,13 +27,21 @@ white = '\033[97m'
 yellow = '\033[93m'
 end = '\033[0m'
 
-#cookie = '<your facebook cookie>'
-cookie ="sb=boLvXDSrzYhVnIKWXOFFW041; datr=boLvXPKbLlyVoB80_a3jBYga; c_user=100001279151010; xs=81%3AsekDgdXtTHvMpg%3A2%3A1559200373%3A9277%3A4202; dpr=1.125; ; spin=r.1001023063_b.trunk_t.1565064737_s.1_v.2_; fr=04L1QWkX5tO2cXBfm.AWUZ47IHTKAlNM_-5JktDQIYrxE.Bc7meN.yw.F1G.0.0.BdSP4i.AWUFvl3v; wd=1091x838; presence=EDvF3EtimeF1565064744EuserFA21B01279151010A2EstateFDutF1565064744973CEchFDp_5f1B01279151010F1CC"
+cookie = args.cookie or None #'<your facebook cookie>'
+if not cookie:
+    raise Exception("Add facebook cookie to use goop")
 
 if count:
-    pages = count
+    pages = range(count)
+elif pages:
+    pages = range(pages)
+elif page:
+    pages = range(page, page+1)
+elif custom_range:
+    start, end = custom_range
+    pages = range(start, end)
 
-for page in range(pages):
+for page in pages:
     result = goop.search(query, cookie, page=page, full=True, count=count)
 
     for each in result:

--- a/goop/goop.py
+++ b/goop/goop.py
@@ -17,7 +17,7 @@ def decode_html(string):
         new_string = new_string.replace(e, d)
     return new_string
 
-def parse(string):
+def parse(string, count):
     "extract and parse resutls"
     parsed = {}
     pattern = r'''<div><div class="[^"]+">
@@ -30,9 +30,11 @@ def parse(string):
     for match in matches:
         parsed[num] = {'url' : match.group(1), 'text' : match.group(2), 'summary' : match.group(3) or match.group(4)}
         num += 1
+        if count and count == num:
+            break
     return parsed
 
-def search(query, cookie, page=0, full=False):
+def search(query, cookie, page=0, full=False, count=None):
     """
     main function, returns parsed results
     Args:
@@ -57,5 +59,5 @@ def search(query, cookie, page=0, full=False):
     }
     response = requests.get('https://developers.facebook.com/tools/debug/echo/?q=%s' % escaped, headers=headers)
     cleaned_response = decode_html(response.text)
-    parsed = parse(cleaned_response)
+    parsed = parse(cleaned_response, count)
     return parsed


### PR DESCRIPTION
THIS PR;
1. Closes #4 by adding `--count/-c` parameter to cli
2. Implements full cli interface
3. Adds .gitignore

Cli interface options:
`--query`: Mandatory
`--pages/-P`: Fetches results from n number of pages
`--count/-C`: Fetches n number of results as specified

Ex:
`python cli.py --query "random work" -c 3` #fetches only 3 results
`python cli.py --query "random work" -P 3` #fetches results of 3 pages

`python cli.py --query "random work" -P 3 -c 4` #Wrong usage
**Note:** `--pages` and `--count` are used as mutually exclusive i.e only one of them can be passed as an argument to the cli.